### PR TITLE
fix: scroll when showing it inside a modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ export default function Home() {
 | `searchPlaceholder` | `string` | "Search for an icon..." | The placeholder for the search input |
 | `triggerPlaceholder` | `string` | "Select an icon" | The text displayed on the default trigger button when no icon is selected |
 | `iconsList` | `IconList` | all lucide icons | The list of icons to display in the picker |
-| `categorized` | `boolean` | `true` | Display icons in categories and add categories buttons to scroll to the desired category. |
+| `categorized` | `boolean` | `true` | Display icons in categories and add categories buttons to scroll to the desired category |
+| `modal` | `boolean` | `false` | Whether the icon picker is being rendered in a modal |
 
 ## Development
 

--- a/registry/ui/icon-picker.tsx
+++ b/registry/ui/icon-picker.tsx
@@ -29,6 +29,7 @@ interface IconPickerProps extends Omit<React.ComponentPropsWithoutRef<typeof Pop
   triggerPlaceholder?: string
   iconsList?: IconData[]
   categorized?: boolean
+  modal?: boolean
 }
 
 const IconRenderer = React.memo(({ name }: { name: IconName }) => {
@@ -94,6 +95,7 @@ const IconPicker = React.forwardRef<
   triggerPlaceholder = "Select an icon",
   iconsList,
   categorized = true,
+  modal = false,
   ...props
 }, ref) => {
   const [selectedIcon, setSelectedIcon] = useState<IconName | undefined>(defaultValue)
@@ -378,7 +380,7 @@ const IconPicker = React.forwardRef<
   }, [isPopoverVisible, virtualizer]);
 
   return (
-    <Popover open={open ?? isOpen} onOpenChange={handleOpenChange}>
+    <Popover open={open ?? isOpen} onOpenChange={handleOpenChange} modal={modal}>
       <PopoverTrigger ref={ref} asChild {...props}>
         {children || (
           <Button variant="outline">

--- a/src/components/icon-picker-props.tsx
+++ b/src/components/icon-picker-props.tsx
@@ -79,6 +79,12 @@ import {
       type: "boolean",
       default: "true",
       description: "Display icons in categories and add categories buttons to scroll to the desired category.",
+    },
+    {
+      prop: "modal",
+      type: "boolean",
+      default: "false",
+      description: "Whether the icon picker is being rendered in a modal.",
     }
   ]
   


### PR DESCRIPTION
When the icon picker is being kept inside the modal, the scroll functionality doesn't work. That is because the popover library from needs the modal prop to correctly work.
Hence we will add the same prop and pass it on to popover library as well

Fixes: #12 