### PR TITLE
Fix: Cannot scroll the popover when rendered inside the modal although the `modal` is set to `false`

### DIFF
--- a/registry/ui/icon-picker.tsx
+++ b/registry/ui/icon-picker.tsx
@@ -405,14 +405,29 @@ const IconPicker = React.forwardRef<
           />
         )}
         {categorized && search.trim() === "" && (
-          <div className="flex flex-row gap-1 mt-2 overflow-x-auto pb-2">
+          <div
+            className='flex flex-row gap-1 mt-2 overflow-x-auto pb-2'
+            style={{
+              scrollbarWidth: 'thin',
+              touchAction: 'pan-x',
+              overscrollBehavior: 'contain',
+            }}
+            onWheel={(e) => e.stopPropagation()}
+            onTouchMove={(e) => e.stopPropagation()}
+          >
             {categoryButtons}
           </div>
         )}
         <div
           ref={parentRef}
           className="max-h-60 overflow-auto"
-          style={{ scrollbarWidth: 'thin' }}
+          style={{
+            scrollbarWidth: 'thin',
+            touchAction: 'pan-y',
+            overscrollBehavior: 'contain',
+          }}
+          onWheel={(e) => e.stopPropagation()}
+          onTouchMove={(e) => e.stopPropagation()}
         >
           {isLoading ? (
             <IconsColumnSkeleton />


### PR DESCRIPTION
# Context

Currently when i use the IconPicker within the modal, i cannot scroll the popover as well as the categories y scroll

## Description

This pull request improves the user experience of the icon picker component in `registry/ui/icon-picker.tsx` by refining scroll behavior and event handling for both horizontal and vertical scroll areas. The main changes focus on preventing unwanted scroll propagation and enhancing touch interactions.

**Scroll behavior and event handling improvements:**

* Added `scrollbarWidth: 'thin'`, `touchAction`, and `overscrollBehavior` styles to both the category button row and the icon list to improve scrolling experience and prevent scroll chaining.
* Added `onWheel` and `onTouchMove` event handlers to both scrollable areas to stop event propagation, ensuring that scrolling within these areas does not affect parent containers.